### PR TITLE
Update Pivot4J plugin to build #275.

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -918,9 +918,9 @@ IP Locator Component
             <version>
                 <branch>Development</branch>
                 <version>0.9-SNAPSHOT</version>
-                <build_id>271</build_id>
+                <build_id>275</build_id>
                 <name>Latest snapshot build</name>
-                <package_url>http://dev.eyeq.co.kr/jenkins/job/Pivot4J/lastSuccessfulBuild/artifact/pivot4j-pentaho/target/pivot4j-pentaho-0.9-SNAPSHOT-plugin.zip</package_url>
+                <package_url>http://dev.eyeq.co.kr/jenkins/job/Pivot4J/275/artifact/pivot4j-pentaho/target/pivot4j-pentaho-0.9-SNAPSHOT-plugin.zip</package_url>
                 <description>The latest development snapshot build.</description>
                 <min_parent_version>5.0</min_parent_version>
             </version>


### PR DESCRIPTION
Update Pivot4J plugin to build #275.
- Initial charting and cell write-back support.
- Minor bug fixes.
- Use a permanent link.
