### PR TITLE
PDI CMIS Input Plugin v1.1.

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -703,15 +703,15 @@ http://www.apache.org/licenses/LICENSE-2.0.html</license_text>
      <support_url>http://www.pentaho.com/services/support/pdi</support_url>
    </market_entry>
    
-   <market_entry>
+<market_entry>
       <id>CmisInput</id>
       <type>Step</type>
       <name>CMIS Input</name>
       <description>The CMIS Input plugin make you able to extract from your Enterprise Content Management System. 
 All the metadata of your documents can be retrieved using simple queries with a query language very close to the traditional SQL.</description>
-      <documentation_url>http://francescocorti.wordpress.com/pdi-cmis-input/</documentation_url>
+      <documentation_url>http://fcorti.com/pdi-cmis-input/</documentation_url>
       <author>Francesco Corti</author>
-      <author_url>http://francescocorti.wordpress.com</author_url>
+      <author_url>http://fcorti.com</author_url>
       <author_logo>http://francescocorti.files.wordpress.com/2012/12/copy-francescosmall1.jpg</author_logo>
       <img>http://francescocorti.files.wordpress.com/2013/01/cmisinput.png</img>
       <small_img>http://francescocorti.files.wordpress.com/2013/04/cmisinput.png</small_img>
@@ -719,17 +719,17 @@ All the metadata of your documents can be retrieved using simple queries with a 
       <versions>
         <version>
           <branch>Stable</branch>
-          <version>1.0</version>
+          <version>1.1</version>
           <name>1.0</name>
-          <package_url>https://cmis-input-plugin.googlecode.com/files/CMIS%20Input%20plugin%20v1.0%20for%20the%20marketplace.zip</package_url>
+          <package_url>https://cmis-input-plugin.googlecode.com/files/CMIS%20Input%20plugin%20v1.1%20for%20the%20marketplace.zip</package_url>
           <description>Release of the plugin.</description>
-          <changelog>First release</changelog>
+          <changelog>Pentaho 5 compliance and OpenCMIS 0.10.0 (Apache Chemistry).</changelog>
           <build_id>1</build_id>
-          <min_parent_version>4.4</min_parent_version>
+          <min_parent_version>5.0</min_parent_version>
         </version>
       </versions>
    </market_entry> 
-   
+
     <market_entry>
      <id>BucketPartitioner</id>
      <type>Partitioner</type>


### PR DESCRIPTION
Updated the PDI CMIS Input Plugin to v1.1.

Change log:
- Compliance to Pentaho 5.
- OpenCMIS 0.10.0 (Apache Chemistry)

http://fcorti.com/pdi-cmis-input/
