### PR TITLE
New BTable version

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -1091,14 +1091,23 @@ that sits on 2 major cornerstones:
 		<versions>
 			<version>
 				<branch>STABLE</branch>
-				<version>1.0</version>
+				<version>1.5</version>
 				<name>Stable</name>
-				<package_url>http://downloads.sourceforge.net/project/btable/Version1.0/BTable-STABLE-1.0.zip</package_url>
-				<description>Release 1.0</description>
-				<build_id>manual-20131028</build_id>
+				<package_url>http://sourceforge.net/projects/btable/files/Version1.5/BTable-pentaho4-STABLE-1.5.zip/download</package_url>
+				<description>Release 1.5</description>
+				<build_id>manual-20131223</build_id>
                 <max_parent_version>4.8</max_parent_version>
                 <min_parent_version>1.0</min_parent_version>				
-			</version>    	                    		
+			</version>
+            <version>
+                <branch>STABLE</branch>
+                <version>1.5</version>
+                <name>Stable</name>
+                <package_url>http://sourceforge.net/projects/btable/files/Version1.5/BTable-pentaho5-STABLE-1.5.zip/download</package_url>
+                <description>Release 1.5</description>
+                <build_id>manual-20131223</build_id>
+                <min_parent_version>5.0</min_parent_version>
+            </version>                  		
 		</versions>		
 	   <screenshots>
 			 <screenshot>http://www.biztech.it/btable/img/BTable-Screenshot-01.png</screenshot>


### PR DESCRIPTION
BTable is now available for Pentaho 5.0
