### PR TITLE
Update Pivot4J plugin to 297 version.

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -465,9 +465,9 @@
 			<version>
 				<branch>Development</branch>
 				<version>0.9-SNAPSHOT</version>
-				<build_id>292</build_id>
+				<build_id>297</build_id>
 				<name>Latest snapshot build</name>
-				<package_url>http://ci.greencatsoft.com/job/Pivot4J/292/artifact/pivot4j-pentaho/target/pivot4j-pentaho-0.9-SNAPSHOT-plugin.zip</package_url>
+				<package_url>http://ci.greencatsoft.com/job/Pivot4J/297/artifact/pivot4j-pentaho/target/pivot4j-pentaho-0.9-SNAPSHOT-plugin.zip</package_url>
 				<description>The latest development snapshot build.</description>
 				<min_parent_version>5.0</min_parent_version>
 			</version>


### PR DESCRIPTION
It contains some changes to make it work with Pentaho language pack.

Thanks!
