### PR TITLE
Fix folder structure for ic-amqp-plugin and ic-filter-plugin

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -2288,8 +2288,8 @@ This step detects identical, changed, added and removed rows.</description>
         <license_text>For more details see: https://raw.github.com/instaclick/PDI-Plugin-Step-AMQP/master/LICENSE.md</license_text>
         <versions>
             <version>
-                <version>1.0.0</version>
-                <package_url>https://raw.github.com/instaclick/pdi-marketplace-packages/master/ic-amqp-plugin-pdi-1.0.0-SNAPSHOT.tar</package_url>
+                <version>1.1.1</version>
+                <package_url>https://raw.github.com/instaclick/pdi-marketplace-packages/master/ic-amqp-plugin-pdi-1.1.1-SNAPSHOT.zip</package_url>
             </version>
         </versions>
     </market_entry>
@@ -2305,8 +2305,8 @@ This step detects identical, changed, added and removed rows.</description>
         <license_text>For more details see: https://raw.github.com/instaclick/PDI-Plugin-Step-BloomFilter/master/LICENSE.md</license_text>
         <versions>
             <version>
-                <version>1.7.0</version>
-                <package_url>https://raw.github.com/instaclick/pdi-marketplace-packages/master/ic-filter-plugin-pdi-1.7.0-SNAPSHOT.tar</package_url>
+                <version>1.8.1</version>
+                <package_url>https://raw.github.com/instaclick/pdi-marketplace-packages/master/ic-filter-plugin-pdi-1.8.1-SNAPSHOT.zip</package_url>
             </version>
         </versions>
     </market_entry>


### PR DESCRIPTION
Hi Guys

This path fix the folder structure for ic-amqp-plugin and ic-filter-plugin 
and change the package format from `tar` to `zip`

See https://github.com/pentaho/marketplace-metadata/pull/57

```
unzip -Z -1 ic-amqp-plugin-pdi-1.1.1-SNAPSHOT.zip 
ic-amqp-plugin/
ic-amqp-plugin/ic-amqp-plugin.jar
ic-amqp-plugin/logo.png
ic-amqp-plugin/plugin.xml
```

```
unzip -Z -1  ic-filter-plugin-pdi-1.8.1-SNAPSHOT.zip 
ic-filter-plugin/
ic-filter-plugin/ic-filter-plugin.jar
ic-filter-plugin/lib/***.jar
ic-filter-plugin/logo.png
ic-filter-plugin/plugin.xml
```
