### PR TITLE
Update Pivot4J plugin to the build 325.

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -565,9 +565,9 @@
 			<version>
 				<branch>Development</branch>
 				<version>0.9-SNAPSHOT</version>
-				<build_id>315</build_id>
+				<build_id>325</build_id>
 				<name>Latest snapshot build</name>
-				<package_url>http://ci.greencatsoft.com/job/Pivot4J/315/artifact/pivot4j-pentaho/target/pivot4j-pentaho-0.9-SNAPSHOT-plugin.zip</package_url>
+				<package_url>http://ci.greencatsoft.com/job/Pivot4J/325/artifact/pivot4j-pentaho/target/pivot4j-pentaho-0.9-SNAPSHOT-plugin.zip</package_url>
 				<description>The latest development snapshot build.</description>
 				<min_parent_version>5.0</min_parent_version>
 			</version>


### PR DESCRIPTION
- New charting API.
- Fix issues with Mondrian roles on Pentaho platform.
- UI improvements.
