### PR TITLE
Added Map value type to PDI

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -2319,6 +2319,26 @@
 		<support_url>http://kettle.pentaho.com</support_url>
 	</market_entry>
 
+	<market_entry>
+		<id>pdi-valuemeta-map</id>
+		<type>Mixed</type>
+		<name>Map (key/value pair) type</name>
+		<description>This plugin provides a ValueMeta plugin for key/value pairs (backed by a java.util.Map) </description>
+		<author>Matt Burgess</author>
+		<documentation_url>https://github.com/mattyb149/pdi-valuemeta-map/wiki</documentation_url>
+		<versions>
+			<version>
+				<version>1.0</version>
+				<package_url>https://pentaho.box.com/shared/static/mcjdlfp3s5z30wxnx04u.zip</package_url>
+			</version>
+		</versions>
+		<license_name>Apache 2.0</license_name>
+		<license_text>For more details about the Apache v2.0 license see: http://www.apache.org/licenses/LICENSE-2.0.html</license_text>
+		<support_level>COMMUNITY_SUPPORTED</support_level>
+		<support_message>Supported by the Pentaho Data Integration developer community.</support_message>
+		<support_organization>Pentaho Developer Community</support_organization>
+		<support_url>http://kettle.pentaho.com</support_url>
+	</market_entry>
 
 	<market_entry>
 		<id>tdeoutputplugin</id>


### PR DESCRIPTION
Allows key/value pairs to be passed as a single value/cell in a PDI row. Possibly useful for properties files, property node graphs, etc.
