### PR TITLE
Add PDI Groovy Console plugin

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -413,7 +413,7 @@
 		    <package_url>http://ci.pentaho.com/job/Sparkl/lastSuccessfulBuild/artifact/dist/sparkl-TRUNK-SNAPSHOT.zip</package_url>
     		<description>@PLUGIN_PACKAGE_DESCRIPTION@</description>
 	    	<build_id>57</build_id>
-            <min_parent_version>5.0</min_parent_version>
+            <min_parent_version>5.0</min_parent_version>		
 		</version>
 		</versions>
 		<screenshots>
@@ -487,7 +487,7 @@
 				<max_parent_version>4.9</max_parent_version>
 				<min_parent_version>1.0</min_parent_version>
 			</version>
-				<version>
+			<version>
 				<branch>STABLE</branch>
 				<version>2.6</version>
 				<name>Stable</name>
@@ -496,13 +496,13 @@
 				<min_parent_version>5.0</min_parent_version>
 			</version>
 <version>
-                                <branch>TRUNK</branch>
+				<branch>TRUNK</branch>
                                 <version>Trunk</version>
-                                <name>Trunk</name>
+				<name>Trunk</name>
                                 <package_url>http://ci.analytical-labs.com/job/saiku-bi-platform-plugin-p5/lastSuccessfulBuild/artifact/saiku-bi-platform-plugin-p5/target/saiku-plugin-p5-3.0-SNAPSHOT.zip</package_url>
                                 <description>Trunk Snapshot. Install at your own risk...</description>
-                                <min_parent_version>5.0</min_parent_version>
-                        </version>
+				<min_parent_version>5.0</min_parent_version>
+			</version>
 
 		
 		</versions>
@@ -557,7 +557,7 @@
 			<screenshot>https://a.fsdn.com/con/app/proj/saikuchartplus/screenshots/PieChartPlus.png</screenshot>
 		</screenshots>
 	</market_entry>
-	
+
 	<market_entry>
 		<id>IvyBC</id>
 		<type>Platform</type>
@@ -1354,20 +1354,20 @@
 		<img>http://www.webdetails.pt/ficheiros/envdisplay.png</img>
 		<small_img>http://www.webdetails.pt/ficheiros/envdisplay_plugin.png</small_img>
 		<description>
-		      <![CDATA[Plugin that gives information about system and session
-		      environment information useful for development and debugging. Even though
-		      it's not sensitive information, it's not recommended to have this plugin
-		      installed in a production environment  <br /><br /> Report <a
-		        href="http://redmine.webdetails.org/projects/envdisplay">here</a> any
-		      issues or suggestions for improvement ]]>
+      <![CDATA[Plugin that gives information about system and session
+      environment information useful for development and debugging. Even though
+      it's not sensitive information, it's not recommended to have this plugin
+      installed in a production environment  <br /><br /> Report <a
+        href="http://redmine.webdetails.org/projects/envdisplay">here</a> any
+      issues or suggestions for improvement ]]>
 		</description>
-    	<documentation_url>https://github.com/webdetails/environmentDisplay</documentation_url>
+    <documentation_url>https://github.com/webdetails/environmentDisplay</documentation_url>
 		<author>Webdetails</author>
 		<author_url>http://www.webdetails.pt</author_url>
 		<author_logo>http://www.webdetails.pt/ficheiros/wd_logo.png</author_logo>
 		<license>MPL 2.0</license>
 		<dependencies>CDF, CDA, CDE, CGG</dependencies>
-    	<installation_notes/>
+    <installation_notes/>
 		<versions>
 			<version>
 				<branch>RELEASE</branch>
@@ -1382,7 +1382,7 @@
 			</version>
 		</versions>
 		<screenshots>
-      		<screenshot>https://raw.githubusercontent.com/webdetails/environmentDisplay/release/resources/img/screenshot_1.png</screenshot>
+      <screenshot>https://raw.githubusercontent.com/webdetails/environmentDisplay/release/resources/img/screenshot_1.png</screenshot>
 		</screenshots>
 	</market_entry>
 
@@ -1909,16 +1909,16 @@
 			]]>
 		</installation_notes>
 		<versions>
-			<version>
-				<branch>RELEASE</branch>
+		<version>
+		<branch>RELEASE</branch>
 				<version>0.7</version>
 				<name>RELEASE</name>
 				<package_url>http://ci.analytical-labs.com/job/Webdetails-languagePackInstallers/lastSuccessfulBuild/artifact/dist/languagePack_ja-RELEASE-0.7.zip</package_url>
-				<samples_url/>
+			<samples_url/>
 				<description>Latest Release</description>
-				<changelog/>
-				<build_id/>
-				<min_parent_version>5.0</min_parent_version>
+			<changelog/>
+			<build_id/>
+			<min_parent_version>5.0</min_parent_version>
 				<max_parent_version>5.0.99</max_parent_version>			
 			</version>
 			<version>
@@ -2101,19 +2101,19 @@
 
 		  ]]>
 	  </installation_notes>
-	  	<versions>
-			<version>
-				<branch>RELEASE</branch>
+	  <versions>
+	    <version>
+	      <branch>RELEASE</branch>
 				<version>0.5.2</version>
 				<name>RELEASE</name>
-				<package_url>http://ci.analytical-labs.com/job/Webdetails-languagePackInstallers/lastSuccessfulBuild/artifact/dist/languagePack_pt_PT-RELEASE-0.5.2.zip</package_url>
-				<samples_url/>
+	      <package_url>http://ci.analytical-labs.com/job/Webdetails-languagePackInstallers/lastSuccessfulBuild/artifact/dist/languagePack_pt_PT-RELEASE-0.5.2.zip</package_url>
+	      <samples_url/>
 				<description>Latest Release</description>
-				<changelog/>
-				<build_id/>
-				<min_parent_version>5.0</min_parent_version>
+	      <changelog/>
+	      <build_id/>
+	      <min_parent_version>5.0</min_parent_version>
 				<max_parent_version>5.0.99</max_parent_version>	      
-			</version>
+	    </version>
 			<version>
 				<branch>RELEASE</branch>
 				<version>14.07.03</version>
@@ -2126,7 +2126,7 @@
 				<min_parent_version>5.1</min_parent_version>
 				<max_parent_version>5.1.99</max_parent_version>
 			</version>
-	  	</versions>
+	  </versions>
 	  <screenshots>
 			<screenshot>https://raw.github.com/webdetails/pentahoLanguagePacks/master/data/pt_PT/resources/img/screenshot_1.png</screenshot>
 			<screenshot>https://raw.github.com/webdetails/pentahoLanguagePacks/master/data/pt_PT/resources/img/screenshot_2.png</screenshot>
@@ -2618,14 +2618,14 @@
 			• Parse names, genderize, and detect suspicious words or companies in name field
 			• Geocode addresses by assigning rooftop lat/long coordinates
 			• USPS CASS certified engine
-			
+
 			Processing Options - (Local)(Cloud)(Dedicated Cloud) 
 
 			SmartMover Component
 			• U.S./Canadian change of address processing to update addresses of people or
-			  businesses that have moved
+			businesses that have moved
 			• USPS Certified NCOA (National Change of Address) 
-			
+
 			Processing Options -(Cloud Only)
 
 			MatchUp Component
@@ -2638,7 +2638,7 @@
 			• Identify web visitor's geographic location
 			• Append Latitude, longitude, ISP, City, State, Country
 			• Reduce fraud and geo target
-			
+
 			Processing Options -(Local)(Cloud)(Dedicated Cloud) 
 
 		</description>
@@ -3476,4 +3476,31 @@ a graphical tool for statistical analysis.
 		<support_url>http://kettle.pentaho.com</support_url>
 	</market_entry>
 
+
+    <market_entry>
+     <id>GroovyConsoleSpoonPlugin</id>
+     <type>SpoonPlugin</type>
+     <name>PDI Groovy Console</name>
+     <description>This plugin (for PDI 5.0+) adds a Groovy console to the Help menu that has some helper methods 
+and classes to interact with the PDI environment.</description>
+     <author>Matt Burgess</author> 
+     <forum_url>http://forums.pentaho.com/forumdisplay.php?269-Data-Integration-Kettle</forum_url>
+     <cases_url>http://jira.pentaho.com/browse/PDI</cases_url>
+     <license_name>Apache License 2.0</license_name>
+     <license_text>For more details see: http://www.apache.org/licenses/LICENSE-2.0.html</license_text>
+     <support_level>COMMUNITY_SUPPORTED</support_level>
+     <support_message>Supported by a community of volunteers</support_message>
+     <support_organization>none</support_organization>
+     <support_url>https://github.com/mattyb149/GroovyConsoleSpoonPlugin/wiki</support_url>
+     <versions>
+        <version>
+         <branch>master</branch>
+         <version>2.0</version>
+         <name>2.0</name>
+         <package_url>https://pentaho.box.com/shared/static/09jfpshf5tgcgo0so8la.zip</package_url>
+         <source_url>https://github.com/mattyb149/GroovyConsoleSpoonPlugin</source_url>
+         <min_parent_version>5.0</min_parent_version>
+       </version>
+     </versions>
+   </market_entry>
 </market>

--- a/marketplace.xsd
+++ b/marketplace.xsd
@@ -322,6 +322,13 @@
           </xsd:documentation>
         </xsd:annotation>
       </xsd:enumeration>
+      <xsd:enumeration value="SpoonPlugin">
+        <xsd:annotation>
+          <xsd:documentation>
+            This market entry is a Spoon plugin, possibly a perspective or something that adds to the PDI UI. 
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:enumeration>
     </xsd:restriction>
   </xsd:simpleType>
   


### PR DESCRIPTION
Adds a Groovy Console to Spoon, which allows you to do Groovy scripting inside the Spoon IDE using the Kettle APIs.

Related blog posts:

http://funpdi.blogspot.com/2012/10/getting-groovy-with-pdi.html
http://funpdi.blogspot.com/2012/10/groovy-console-spoon-plugin-update.html
http://funpdi.blogspot.com/2012/12/groovyconsolespoonplugin-with-jsr-223.html
