### PR TITLE
Add Gremlin (graph pipeline processing) script step to PDI

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -3503,4 +3503,26 @@ and classes to interact with the PDI environment.</description>
        </version>
      </versions>
    </market_entry>
+
+    <market_entry>
+        <id>pdi-gremlin-plugin</id>
+        <type>Step</type>
+        <name>Gremlin Script step</name>
+        <description>This plugin offers a Gremlin (see https://github.com/tinkerpop/gremlin/wiki) script
+step for graph pipeline processing.</description>
+        <author>Matt Burgess</author>
+        <documentation_url>https://github.com/mattyb149/pdi-graph-computing/wiki</documentation_url>
+        <versions>
+            <version>
+                <version>1.0</version>
+                <package_url>https://pentaho.box.com/shared/static/zzoi8egt5pbd9zabct88.zip</package_url>
+            </version>
+        </versions>
+        <license_name>Apache 2.0</license_name>
+        <license_text>For more details about the Apache v2.0 license see: http://www.apache.org/licenses/LICENSE-2.0.html</license_text>
+        <support_level>COMMUNITY_SUPPORTED</support_level>
+        <support_message>Supported by the Pentaho Data Integration developer community.</support_message>
+        <support_organization>Pentaho Developer Community</support_organization>
+        <support_url>http://kettle.pentaho.com</support_url>
+    </market_entry>
 </market>


### PR DESCRIPTION
See https://github.com/tinkerpop/gremlin/wiki for more information on Gremlin.

Sample transformation read_graphson.ktr (and supporting file funweek.gson) on Box:

https://pentaho.box.com/s/ngg6ceex7vi9q1rn1833
