### PR TITLE
Updated Tika (Load File Contents) PDI step to 1.1

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -3784,6 +3784,10 @@ any translation issues or suggestions for improvement
     <documentation_url>https://github.com/mattyb149/load-text-from-file-plugin/wiki</documentation_url>
     <versions>
       <version>
+        <version>1.1</version>
+        <package_url>https://pentaho.box.com/shared/static/i9z811v11h1wtwf7v6ku.zip</package_url>
+      </version>
+      <version>
         <version>1.0</version>
         <package_url>https://pentaho.box.com/shared/static/lg3yh7fupujhl2gb9vxj.zip</package_url>
       </version>


### PR DESCRIPTION
This update does the following:

1) Migrate from Ant/Ivy/Subfloor to Gradle
2) Update Tika from 1.3 to 1.6
3) Workaround (for local files only) for a VFS bug that closes the stream when reading some files < 64KB (PDFs, e.g.)
