### PR TITLE
Pentaho mongodb delete plugin

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -5355,20 +5355,19 @@ any translation issues or suggestions for improvement
     <id>pentaho-mongodb-delete-plugin</id>
     <type>Step</type>
     <name>MongoDB Delete Plugin</name>
-    <description>Delete document inside a Mongo DB collection</description>
+    <description>Delete document inside a MongoDB collection</description>
     <author>Maas Dianto</author>
     <author_url>https://github.com/maasdi</author_url>
     <author_logo/>
     <installation_notes/>
-    <documentation_url>https://github.com/maasdi/pentaho-mongodb-delete-plugin/blob/master/README.markdown</documentation_url>
+    <documentation_url>https://github.com/maasdi/pentaho-mongodb-delete-plugin/wiki/MongoDB-Delete</documentation_url>
     <versions>
       <version>
         <branch>master</branch>
         <version>1.0.0-RELEASE</version>
-        <build_id/>
+        <build_id>20141022-2338</build_id>
         <name>1.0.0-RELEASE</name>
         <package_url>https://github.com/maasdi/pentaho-mongodb-delete-plugin/releases/download/1.0.0-RELEASE/pentaho-mongodb-delete-plugin-1.0.0-RELEASE.zip</package_url>
-        <source_url>https://github.com/maasdi/pentaho-mongodb-delete-plugin</source_url>
       </version>
     </versions>
     <cases_url>https://github.com/maasdi/pentaho-mongodb-delete-plugin/issues</cases_url>


### PR DESCRIPTION
Register pentaho mongodb delete plugin, step plugin to enables you delete document inside MongoDB collection from PDI
