### PR TITLE
Add PDI Extension Point scripting plugin

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -5452,4 +5452,40 @@ any translation issues or suggestions for improvement
     <support_level>NOT_SUPPORTED</support_level>
   </market_entry>
   
+  <market_entry>
+    <id>pdi-script-extension-points</id>
+    <type>Mixed</type>
+    <name>PDI Extension Point Scripting</name>
+    <category>
+      <name>Enhancements</name>
+      <parent>
+        <name>PDI Plugins</name>
+      </parent>
+    </category>
+    <description>This set of extension point plugins allows the user to write scripts in JavaScript, Groovy, etc.
+that will be called as extension point functions. For example, the user can write a script called TransformationStart.groovy 
+and it will be executed when a transformation starts. All the extension points (up through 5.2) are supported.
+    </description>
+    <author>Matt Burgess</author>
+    <author_url>http://funpdi.blogspot.com</author_url>
+    <documentation_url>https://github.com/mattyb149/pdi-script-extension-points/wiki</documentation_url>
+    <versions>
+      <version>
+        <version>1.0</version>
+        <package_url>https://pentaho.box.com/shared/static/j0wo05woqgur434h7oti.zip</package_url>
+        <development_stage>
+          <lane>Community</lane>
+          <phase>3</phase>
+        </development_stage>
+      </version>
+    </versions>
+    <license_name>Apache 2.0</license_name>
+    <license_text>For more details about the Apache v2.0 license see: http://www.apache.org/licenses/LICENSE-2.0.html
+    </license_text>
+    <support_level>COMMUNITY_SUPPORTED</support_level>
+    <support_message>Supported by the Pentaho Data Integration developer community.</support_message>
+    <support_organization>Pentaho Developer Community</support_organization>
+    <support_url>http://kettle.pentaho.com</support_url>
+  </market_entry>
+  
 </market>


### PR DESCRIPTION
This set of extension point plugins allows the user to write scripts in JavaScript, Groovy, etc. that will be called as extension point functions. For example, the user can write a script called TransformationStart.groovy and it will be executed when a transformation starts. All the extension points (up through 5.2) are supported.

Two examples (TransformationStart.groovy and TransformationFinish.js) are included to show that the two engines that come with PDI (Groovy and Rhino-JS, respectively) can be used to run scripts as execution point methods.
