### PR TITLE
Updated PDI Extension Point Scripting to 1.1

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -5524,14 +5524,15 @@ any translation issues or suggestions for improvement
     <description>This set of extension point plugins allows the user to write scripts in JavaScript, Groovy, etc.
 that will be called as extension point functions. For example, the user can write a script called TransformationStart.groovy 
 and it will be executed when a transformation starts. All the extension points (up through 5.2) are supported.
+Version 1.1 includes Kettle Lifecycle (environmentInit, environmentShutdown) and Lifecycle (onStart, onExit) plugin points as well.
     </description>
     <author>Matt Burgess</author>
     <author_url>http://funpdi.blogspot.com</author_url>
     <documentation_url>https://github.com/mattyb149/pdi-script-extension-points/wiki</documentation_url>
     <versions>
       <version>
-        <version>1.0</version>
-        <package_url>https://pentaho.box.com/shared/static/j0wo05woqgur434h7oti.zip</package_url>
+        <version>1.1</version>
+        <package_url>https://pentaho.box.com/shared/static/m2p0ryd69ra9xvlxzzvv.zip</package_url>
         <development_stage>
           <lane>Community</lane>
           <phase>3</phase>


### PR DESCRIPTION
Added script points for the following:

Kettle Lifecycle Plugins (use the following as prefixes for your script file names):
  environmentInit
  environmentShutdown

Lifecycle Plugins (use the following as prefixes for your script file names):
  onStart
  onExit

I added an onStart.groovy example to the package. When running Spoon, it will now print "Got Lifecycle onStart event" to standard out when the onStart event is received.
