### PR TITLE
Fixed bug in PDI ZooKeeper plugins, updated version

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -5640,9 +5640,9 @@ Version 1.1 includes Kettle Lifecycle (environmentInit, environmentShutdown) and
     <versions>
       <version>
         <branch>Stable</branch>
-        <version>1.1</version>
-        <name>1.1</name>
-        <package_url>https://pentaho.box.com/shared/static/bqmzt007ryqdiijxs7ns.zip</package_url>
+        <version>1.1.1</version>
+        <name>1.1.1</name>
+        <package_url>https://pentaho.box.com/shared/static/exp060vlm0fkoozq6n2z.zip</package_url>
         <min_parent_version>5.0</min_parent_version>
       </version>
     </versions>


### PR DESCRIPTION
The field tables were read-only due to my call to clearAll() instead of removeEmptyRows(). Fixed this and upped the version to 1.1.1
