### PR TITLE
added support for the import.io plugin

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -5666,11 +5666,18 @@ API as well as a connector API. See the documentation for more information.</des
         <license_name>Apache License, Version 2.0</license_name>
         <license_text>For more details see:
 http://www.apache.org/licenses/LICENSE-2.0</license_text>
-        <support_level>NOT_SUPPORTED</support_level>
+        <support_level>PROFESSIONALLY_SUPPORTED</support_level>
+        <support_message>Support by Linalis. Please call +33 1 53 16 45 19 for further information.</support_message>
+        <support_organization>Linalis</support_organization>
+        <support_url>http://www.linalis.fr/fr/linalis/contact</support_url>
         <versions>
             <version>
                 <version>1.0.0</version>
                 <package_url>https://docs.google.com/uc?export=download&amp;id=0B4rmkV4ykvQaWktfQWZydXZNRlk</package_url>
+                <development_stage>
+                    <lane>Community</lane>
+                    <phase>3</phase>
+                </development_stage>
             </version>
         </versions>
     </market_entry>


### PR DESCRIPTION
Another pull request for the import.io plugin. We added support for the plugin as well as the development stage. Feel free to hit me with questions if needed. 

I have 2 questions though : 
- what is the procedure for the plugin to appear there : http://www.pentaho.com/marketplace/ ?
- I can see on this page when you click on a plugin that there 2 buttons (Contact dev and live demo), are there any fields in the marketplace.xml to activate these buttons?

Thanks and regards,

Nicolas
