### PR TITLE
AAAR v2.3 release

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -1609,6 +1609,31 @@ Having trouble with this project? Feel free to report a issue on <a target='NO_B
     <versions>
       <version>
         <branch>STABLE</branch>
+        <version>2.3</version>
+        <name>Stable</name>
+        <package_url>http://sourceforge.net/projects/aaar/files/v2.3/AAAR_v2.3.zip/download</package_url>
+        <samples_url/>
+        <description><![CDATA[
+        Plugin that allows you to install and use Alfresco Audit Analysis and Reporting (A.A.A.R.).<br/>
+        <br/>
+        With A.A.A.R. is provided a solution to extract, store and analyze audit data together with the document/folder informations at a very detailed level, with the goal to be useful to the end-user in a very easy way.
+        ]]>
+        </description>
+        <changelog><![CDATA[
+        - Multiple installations of Alfresco.
+        - Bugfixes.
+        ]]>
+        </changelog>
+        <build_id>1</build_id>
+        <max_parent_version/>
+        <min_parent_version>5.2</min_parent_version>
+        <development_stage>
+          <lane>Community</lane>
+          <phase>3</phase>
+        </development_stage>
+      </version>
+      <version>
+        <branch>STABLE</branch>
         <version>2.2</version>
         <name>Stable</name>
         <package_url>http://sourceforge.net/projects/aaar/files/v2.2/AAAR_v2.2.zip/download</package_url>


### PR DESCRIPTION
AAAR v2.3 release.
AAAR v2.2 still remain valid but the default one is the latest (v2.3).