### PR TITLE
Update Pivot4J to build #379

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -1538,10 +1538,10 @@ Having trouble with this project? Feel free to report a issue on <a target='NO_B
       <version>
         <branch>Development</branch>
         <version>1.0-SNAPSHOT</version>
-        <build_id>364</build_id>
+        <build_id>379</build_id>
         <name>Latest snapshot build</name>
         <package_url>
-          http://ci.greencatsoft.com/job/Pivot4J/364/artifact/pivot4j-pentaho/target/pivot4j-pentaho-1.0-SNAPSHOT-plugin.zip
+          http://ci.greencatsoft.com/job/Pivot4J/379/artifact/pivot4j-pentaho/target/pivot4j-pentaho-1.0-SNAPSHOT-plugin.zip
         </package_url>
         <description>The latest development snapshot build.</description>
         <min_parent_version>5.0</min_parent_version>


### PR DESCRIPTION
* Fix a problem with JPivot migration.
* Fix formatting issue when aggregating on default measure.
* Fix CDE integration problem (blank page).
* Remove an error message on saving report (plugin)
* Update Russian translation.