### PR TITLE
Updated the DataCleaner plugin version to 4.0 (and new download URL)

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -4561,9 +4561,9 @@ With this plugin you can:
     <versions>
       <version>
         <branch>Stable</branch>
-        <version>3.7</version>
+        <version>4.0</version>
         <min_parent_version>5.0.0</min_parent_version>
-        <package_url>http://datacleaner.org/resources/pentaho_plugin/DataCleaner-PDI-plugin-3.7-20141126.zip</package_url>
+        <package_url>http://datacleaner.org/resources/pentaho_plugin/DataCleaner-PDI-plugin-4.0-20150414.zip</package_url>
         <source_url>https://github.com/datacleaner/pdi-datacleaner</source_url>
         <development_stage>
           <lane>Community</lane>


### PR DESCRIPTION
Dear Pentaho,

Please accept our update to the DataCleaner PDI plugin. Now based on version 4.0 of DataCleaner - we're very happy to launch this major new version into your community too :-)

Any comments welcome.

- Kasper, Dennis, Claudia and Tomasz from the DataCleaner team