### PR TITLE
Add: PDI StreamSchemaMerge Plugin

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -7812,4 +7812,40 @@ More on: https://anotherreeshu.wordpress.com/2015/01/13/special-character-remove
   </versions>
 </market_entry>  
 
+  <market_entry>
+    <id>StreamSchemaStep</id>
+    <type>Step</type>
+    <name>Stream Schema Merge</name>
+    <category>
+      <name>Enhancements</name>
+      <parent>
+        <name>PDI Plugins</name>
+      </parent>
+    </category>
+    <documentation_url>https://github.com/graphiq-data/pdi-streamschemamerge-plugin/blob/master/README.md</documentation_url>
+    <description>Takes the union of streams with different schemas and merges them into a single stream. Allows you to merge streams without first changing the order of fields and adding constants for missing fields. If data types conflict, a new value meta will be created with a String type</description>
+    <author>Andrew Overton</author>
+    <author_url>https://team.graphiq.com/l/232/Andrew-Overton</author_url>
+    <license>MIT</license>
+    <support_level>COMMUNITY_SUPPORTED</support_level>
+    <support_message>Supported by Graphiq.com Inc.</support_message>
+    <support_organization>Graphiq</support_organization>
+    <dependencies/>
+    <versions>
+      <version>
+        <branch>BETA</branch>
+        <version>1.0.0</version>
+        <name>Beta</name>
+        <package_url>https://s3-us-west-1.amazonaws.com/pdi-graphiq-marketplace/StreamSchemaMerge.zip</package_url>
+        <source_url>https://github.com/graphiq-data/pdi-streamschemamerge-plugin</source_url>
+        <description>First version of step. Functional tests written, but has not yet been tested extensively in production environment</description>
+        <build_id/>
+        <development_stage>
+          <lane>Community</lane>
+          <phase>1</phase>
+        </development_stage>
+      </version>
+    </versions>
+  </market_entry>
+
 </market>


### PR DESCRIPTION
This step allows you to merge streams with different schemas without first rearranging the fields, adding constants or modifying data meta types.

## Use Cases
Let's say you want to take 2 text files and combine them into 1 text file. 

### Simple Case
+ *Scenario:* The files have the exact same structure and field ordered
+ *Traditional Solution:* Simple transformation that reads in text files and sends rows directly to output

### Complex (Real-Word) Case
+ *Scenario:* The files share 6/10 fields and the other 4 fields are different in each file. The order of column names is not the same in the two files.
+ *Traditional Solution:* Use the Add Constants step to add missing fields, then use the Select Values step to rearrange the fields so they appear in the same order.

### Why Stream Schema Merge is Better
+ While the complex case is a little clunky, it isn't so bad with only 2 streams; however, it rapidly becomes messy and hard to implement as the number of streams increases. It doesn't scale.
+ The Stream Schema Merge step takes care of finding the union of all the fields you pass to it and placing the data values in the appropriate columns. Why use your brain for something a computer can do better? For example,
```
Stream 1 Fields: apple, orange
Stream 2 Fields: orange, banana
Stream 3 Fields: cherry, mango
Result Stream: `apple, orange, banana, cherry, mango`
```
If a stream did not originally contain a column (e.g. mango isn't in stream 1), then the value of that field will be null for all rows originating from that stream.

The source can be found [here](https://github.com/graphiq-data/pdi-streamschemamerge-plugin)