### PR TITLE
Add: PDI UniqueList Plugin

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -8022,7 +8022,7 @@ More on: https://anotherreeshu.wordpress.com/2015/01/13/special-character-remove
       </development_stage>
     </version>
   </versions>
-</market_entry>  
+</market_entry>
 
   <market_entry>
     <id>StreamSchemaStep</id>
@@ -8052,6 +8052,44 @@ More on: https://anotherreeshu.wordpress.com/2015/01/13/special-character-remove
         <source_url>https://github.com/graphiq-data/pdi-streamschemamerge-plugin</source_url>
         <description>First version of step. Functional tests written, but has not yet been tested extensively in production environment</description>
         <build_id/>
+        <development_stage>
+          <lane>Community</lane>
+          <phase>1</phase>
+        </development_stage>
+      </version>
+    </versions>
+  </market_entry>
+
+  <market_entry>
+    <id>UniqueListStep</id>
+    <type>Step</type>
+    <name>Unique List</name>
+    <category>
+      <name>Enhancements</name>
+      <parent>
+        <name>PDI Plugins</name>
+      </parent>
+    </category>
+    <documentation_url>https://github.com/graphiq-data/pdi-uniquelist-plugin/blob/master/README.md</documentation_url>
+    <description>Given a delimited list of items, split the list, deduplicate the items and then rejoin the list together</description>
+    <author>Andrew Overton</author>
+    <author_url>https://team.graphiq.com/l/232/Andrew-Overton</author_url>
+    <cases_url>https://github.com/graphiq-data/pdi-uniquelist-plugin/issues</cases_url>
+    <license>MIT</license>
+    <support_level>COMMUNITY_SUPPORTED</support_level>
+    <support_message>Supported by Graphiq.com Inc.</support_message>
+    <support_organization>Graphiq</support_organization>
+    <dependencies/>
+    <versions>
+      <version>
+        <branch>BETA</branch>
+        <version>1.0.0</version>
+        <name>Beta</name>
+        <build_id/>
+        <package_url>https://s3-us-west-1.amazonaws.com/pdi-graphiq-marketplace/UniqueList.zip</package_url>
+        <source_url>https://github.com/graphiq-data/pdi-uniquelist-plugin</source_url>
+        <description>First version of step. Functional tests written, but has not yet been tested extensively in production environment</description>
+        <build_id>1</build_id>
         <development_stage>
           <lane>Community</lane>
           <phase>1</phase>

--- a/marketplace.xml
+++ b/marketplace.xml
@@ -8086,7 +8086,7 @@ More on: https://anotherreeshu.wordpress.com/2015/01/13/special-character-remove
         <version>1.0.0</version>
         <name>Beta</name>
         <build_id/>
-        <package_url>https://s3-us-west-1.amazonaws.com/pdi-graphiq-marketplace/UniqueList.zip</package_url>
+        <package_url>https://s3-us-west-1.amazonaws.com/pdi-graphiq-marketplace/UniqueListStep.zip</package_url>
         <source_url>https://github.com/graphiq-data/pdi-uniquelist-plugin</source_url>
         <description>First version of step. Functional tests written, but has not yet been tested extensively in production environment</description>
         <build_id>1</build_id>


### PR DESCRIPTION
This step allows you to de-duplicate concatenated lists.

## Use Cases
When moving from normalized to denormalized data or dealing with attributes of an entity you may want a unique list of delimited values. For example, imagine you have a list of all the countries a person has visited, one entry for each city
```
England,Spain,Spain,Belgium,Belgium,Trinidad,Trinidad,Mexico,Trinidad
```
Now, imagine you want each entry in the list to be unique. You can pass the field to the Unique List step and get that result.
```
England,Spain,Belgium,Trinidad,Mexico
```

The source can be found [here](https://github.com/graphiq-data/pdi-uniquelist-plugin)