### PR TITLE
Tapa new <version> for Pentaho 6.0

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -2021,13 +2021,31 @@ It is mandatory to click on the "Refresh Button" on the Pentaho CE Audit Admin S
       <version>
         <branch>STABLE</branch>
         <version>0.3.1</version>
-        <name>Latest snapshot build</name>
+        <name>Latest stable build</name>
         <package_url>
           https://github.com/marpontes/tapa/releases/download/v0.3.1/tapa-0.3.1.zip
         </package_url>
-        <description>Works for both - Pentaho 5.3+ and 6.0</description>
+        <description>Works for Pentaho 5.2.X till 5.4.XX</description>
         <build_id/>
-        <min_parent_version>5.3.0</min_parent_version>
+        <min_parent_version>5.2.0</min_parent_version>
+        <max_parent_version>5.4.99</min_parent_version>
+        <development_stage>
+          <lane>Community</lane>
+          <phase>3</phase>
+        </development_stage>
+      </version>
+
+      <version>
+        <branch>STABLE</branch>
+        <version>0.3.1</version>
+        <name>Latest stable build</name>
+        <package_url>
+          https://github.com/marpontes/tapa/releases/download/v0.3.1/tapa-0.3.1-pentaho6.zip
+        </package_url>
+        <description>Works for Pentaho 6.0.X</description>
+        <build_id/>
+        <min_parent_version>6.0.0</min_parent_version>
+        <max_parent_version>6.0.99</min_parent_version>
         <development_stage>
           <lane>Community</lane>
           <phase>3</phase>

--- a/marketplace.xml
+++ b/marketplace.xml
@@ -2028,7 +2028,7 @@ It is mandatory to click on the "Refresh Button" on the Pentaho CE Audit Admin S
         <description>Works for Pentaho 5.2.X till 5.4.XX</description>
         <build_id/>
         <min_parent_version>5.2.0</min_parent_version>
-        <max_parent_version>5.4.99</min_parent_version>
+        <max_parent_version>5.4.99</max_parent_version>
         <development_stage>
           <lane>Community</lane>
           <phase>3</phase>
@@ -2045,7 +2045,7 @@ It is mandatory to click on the "Refresh Button" on the Pentaho CE Audit Admin S
         <description>Works for Pentaho 6.0.X</description>
         <build_id/>
         <min_parent_version>6.0.0</min_parent_version>
-        <max_parent_version>6.0.99</min_parent_version>
+        <max_parent_version>6.0.99</max_parent_version>
         <development_stage>
           <lane>Community</lane>
           <phase>3</phase>


### PR DESCRIPTION
Downloading a template wasn’t working.

The endpoint is a simple resultfiles kind of etl that should zip those files out to the client.

Jut by replacing cpf-core-*, cpk-core-*, cpf-pentaho* and cpk-pentaho* did the trick, so I’ve created a new branch on the plugin called pentaho5. I’ll keep the old libs there and maintain master to pentaho6 builds.