### PR TITLE
Fixed UniqueListStep double <build_id> tag

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -2126,7 +2126,7 @@ It is mandatory to click on the "Refresh Button" on the Pentaho CE Audit Admin S
           https://github.com/marpontes/tapa/releases/download/v0.3.1/tapa-0.3.1-pentaho6.zip
         </package_url>
         <description>Works for Pentaho 6.0.X</description>
-        <build_id/>
+        <build_id>pentaho6</build_id>
         <min_parent_version>6.0.0</min_parent_version>
         <max_parent_version>6.0.99</max_parent_version>
         <development_stage>

--- a/marketplace.xml
+++ b/marketplace.xml
@@ -8193,7 +8193,6 @@ More on: https://anotherreeshu.wordpress.com/2015/01/13/special-character-remove
         <branch>BETA</branch>
         <version>1.0.0</version>
         <name>Beta</name>
-        <build_id/>
         <package_url>https://s3-us-west-1.amazonaws.com/pdi-graphiq-marketplace/UniqueListStep.zip</package_url>
         <source_url>https://github.com/graphiq-data/pdi-uniquelist-plugin</source_url>
         <description>First version of step. Functional tests written, but has not yet been tested extensively in production environment</description>


### PR DESCRIPTION
There were two <build_id> tags on the UniqueListStep entry.

I assumed the one without value should be removed as it's the default.