### PR TITLE
Additional Version: pdi-fastjsoninput-plugin, support for PDI 6.0

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -9011,7 +9011,19 @@ Capabilities:
         <version>1.0.4</version>
         <package_url>https://s3-us-west-1.amazonaws.com/pdi-graphiq-marketplace/FastJsonInput.zip</package_url>
         <build_id/>
+        <max_parent_version>5.4</max_parent_version>
         <development_stage>
+          <lane>Community</lane>
+          <phase>3</phase>
+        </development_stage>
+      </version>
+      <version>
+        <branch>Stable</branch>
+        <version>2.0.0</version>
+        <package_url>https://s3-us-west-1.amazonaws.com/pdi-graphiq-marketplace/FastJsonInput_PDI6.zip</package_url>
+        <build_id/>
+        <min_parent_version>6.0</min_parent_version>
+        <development_state>
           <lane>Community</lane>
           <phase>3</phase>
         </development_stage>


### PR DESCRIPTION
Adding `v2.0.0` to the marketplace for initial use with PDI 6.0.