### PR TITLE
Add new version of ArtifactCatalog (1.0.1)

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -9668,6 +9668,20 @@ Capabilities:
     <versions>
       <version>
         <branch>master</branch>
+        <version>1.0.1</version>
+        <name>1.0.1</name>
+        <package_url>https://github.com/bluezio/pentaho-artifactCatalog/raw/gh-pages/artifactCatalog-1.0.1.zip</package_url>
+        <description>Second release (2 bugfixes)</description>
+        <build_id>1</build_id>
+
+	<min_parent_version>5.4</min_parent_version>
+	<development_stage>
+          <lane>Community</lane>
+          <phase>3</phase>
+	</development_stage>
+      </version>
+      <version>
+        <branch>master</branch>
         <version>1.0.0</version>
         <name>1.0.0</name>
         <package_url>https://github.com/bluezio/pentaho-artifactCatalog/raw/gh-pages/artifactCatalog-1.0.0.zip</package_url>


### PR DESCRIPTION
Hello,

I have released a new version of ArtifactCatalog with two bugfixes, and I'd like to make sure people get them. Could you please merge this when you can, if it's OK?

Kind regards,
Antonio