### PR TITLE
AAAR v4.3 on Pentaho 6.1

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -3312,6 +3312,35 @@ Having trouble with this project? Feel free to report a issue on <a target='NO_B
     <versions>
       <version>
         <branch>STABLE</branch>
+        <version>4.3</version>
+        <name>Stable</name>
+        <package_url>http://downloads.sourceforge.net/project/aaar/v4.3/AAAR_v4.3.zip</package_url>
+        <samples_url/>
+        <description><![CDATA[
+        Plugin that allows you to install and use Alfresco Audit Analysis and Reporting (A.A.A.R.).<br/>
+        <br/>
+        With A.A.A.R. is provided a solution to extract, store and analyze audit data together with the document/folder informations at a very detailed level, with the goal to be useful to the end-user in a very easy way.
+        ]]>
+        </description>
+        <changelog><![CDATA[
+        - Porting on Pentaho 6.1.
+        - Added flag ‘CLEAN_NODES_DELETED’ in ETL to avoid removed nodes extraction (default = false).
+        - Improvements in terms of execution time (and stability) on huge repositories (tested in production environment with +2 Milion documents and +180.000 instances of workflows).
+        - Separation of Alfresco extraction and data mart import in ETL.
+        - Bugfix on Audit dashoboard not showing charts.
+        - Various bugfixes.
+        ]]>
+        </changelog>
+        <build_id>1</build_id>
+        <max_parent_version>6.1.99</max_parent_version>
+        <min_parent_version>6.1</min_parent_version>
+        <development_stage>
+          <lane>Community</lane>
+          <phase>3</phase>
+        </development_stage>
+      </version>
+      <version>
+        <branch>STABLE</branch>
         <version>4.2</version>
         <name>Stable</name>
         <package_url>http://downloads.sourceforge.net/project/aaar/v4.2/AAAR_v4.2.zip</package_url>


### PR DESCRIPTION
Porting on Pentaho 6.1.
Added flag ‘CLEAN_NODES_DELETED’ in ETL to avoid removed nodes extraction (default = false).
Improvements in terms of execution time (and stability) on huge repositories (tested in production environment with +2 Milion documents and +180.000 instances of workflows).
Separation of Alfresco extraction and data mart import in ETL.
Bugfix on Audit dashoboard not showing charts.
Various bugfixes.