### PR TITLE
Fixed IvyDD Version details

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -2582,7 +2582,7 @@ Having trouble with this project? Feel free to report a issue on <a target='NO_B
         <description>Proof of Concept release 0.0.4</description>
         <build_id/>
         <min_parent_version>5.0</min_parent_version>
-        <max_parent_version>5.4.99</max_parent_version>
+        <max_parent_version>5.4</max_parent_version>
         <development_stage>
           <lane>Community</lane>
           <phase>2</phase>
@@ -2598,6 +2598,7 @@ Having trouble with this project? Feel free to report a issue on <a target='NO_B
         <description>Proof of Concept release 0.0.3 for Saiku 2.6</description>
         <build_id/>
         <min_parent_version>5.0</min_parent_version>
+        <max_parent_version>5.0</max_parent_version>
         <development_stage>
           <lane>Community</lane>
           <phase>2</phase>


### PR DESCRIPTION
This should stop an unsupported version of the IvyDD appearing in Pentaho 6.x