### PR TITLE
AAAR v4.5

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -3260,6 +3260,32 @@ Having trouble with this project? Feel free to report a issue on <a target='NO_B
     <versions>
       <version>
         <branch>STABLE</branch>
+        <version>4.5</version>
+        <name>Stable</name>
+        <package_url>http://downloads.sourceforge.net/project/aaar/v4.5/AAAR_v4.5.zip</package_url>
+        <samples_url/>
+        <description><![CDATA[
+        Plugin that allows you to install and use Alfresco Audit Analysis and Reporting (A.A.A.R.).<br/>
+        <br/>
+        With A.A.A.R. is provided a solution to extract, store and analyze audit data together with the document/folder informations at a very detailed level, with the goal to be useful to the end-user in a very easy way.
+        ]]>
+        </description>
+        <changelog><![CDATA[
+        - Porting to Pentaho 7.0 (bye bye Pentaho 6 from here ahead).
+        - Removed support to Transparent authentication from Alfresco to Pentaho (http://fcorti.com/pentaho-transparent-authentication/).
+        - Bugfixes (in data quality).
+        ]]>
+        </changelog>
+        <build_id>1</build_id>
+        <max_parent_version>7.0.99</max_parent_version>
+        <min_parent_version>7.0</min_parent_version>
+        <development_stage>
+          <lane>Community</lane>
+          <phase>3</phase>
+        </development_stage>
+      </version>
+      <version>
+        <branch>STABLE</branch>
         <version>4.4</version>
         <name>Stable</name>
         <package_url>http://downloads.sourceforge.net/project/aaar/v4.4/AAAR_v4.4.zip</package_url>


### PR DESCRIPTION
- Porting to Pentaho 7.0 (bye bye Pentaho 6 from here ahead).
- Removed support to Transparent authentication from Alfresco to Pentaho. http://fcorti.com/pentaho-transparent-authentication/
- Bugfixes (in data quality).