### PR TITLE
New BTable for Pentaho 5, 6 and 7

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -3084,70 +3084,99 @@ Having trouble with this project? Feel free to report a issue on <a target='NO_B
     <screenshots/>
   </market_entry>
 
-  <market_entry>
-    <id>BTable</id>
-    <type>Platform</type>
-    <img>http://www.biztech.it/btable/img/btable.png</img>
-    <small_img>http://www.biztech.it/btable/img/btable.png</small_img>
-    <name>BTable</name>
-    <category>
-      <name>Dashboards</name>
-      <parent>
-        <name>Apps</name>
-      </parent>
-    </category>
-    <documentation_url>http://www.biztech.it/btable</documentation_url>
-    <description>BTable is a component for the Community Dashboard Designer (CDE) that extends the standard Table
-      Component with OLAP functionalities and provides a new drill experience... drill anywhere!
-    </description>
-    <author>Biz Tech</author>
-    <author_url>http://www.biztech.it</author_url>
-    <author_logo>http://www.biztech.it/btable/img/biztech.png</author_logo>
-    <dependencies>CDE, CDF, CDA</dependencies>
-    <license>MPL 2.0</license>
-    <versions>
-      <version>
-        <branch>STABLE</branch>
-        <version>2.1</version>
-        <name>Stable</name>
-        <package_url>http://downloads.sourceforge.net/project/btable/Version2.1/BTable-pentaho4-STABLE-2.1.zip
-        </package_url>
-        <samples_url>
-          http://downloads.sourceforge.net/project/btable/Version2.1/BTable-samples-pentaho4-STABLE-2.1.zip
-        </samples_url>
-        <description>Release 2.1</description>
-        <build_id>manual-20140610</build_id>
-        <max_parent_version>4.9</max_parent_version>
-        <min_parent_version>1.0</min_parent_version>
-        <development_stage>
-          <lane>Community</lane>
-          <phase>2</phase>
-        </development_stage>
-      </version>
-      <version>
-        <branch>STABLE</branch>
-        <version>2.1</version>
-        <name>Stable</name>
-        <package_url>http://downloads.sourceforge.net/project/btable/Version2.1/BTable-pentaho5-STABLE-2.1.zip
-        </package_url>
-        <samples_url>
-          http://downloads.sourceforge.net/project/btable/Version2.1/BTable-samples-pentaho5-STABLE-2.1.zip
-        </samples_url>
-        <description>Release 2.1</description>
-        <build_id>manual-20140610</build_id>
-        <min_parent_version>5.0</min_parent_version>
-        <development_stage>
-          <lane>Community</lane>
-          <phase>2</phase>
-        </development_stage>
-      </version>
-    </versions>
-    <screenshots>
-      <screenshot>http://www.biztech.it/btable/img/BTable-Screenshot-01.png</screenshot>
-      <screenshot>http://www.biztech.it/btable/img/BTable-Screenshot-02.png</screenshot>
-      <screenshot>http://www.biztech.it/btable/img/BTable-Screenshot-03.png</screenshot>
-    </screenshots>
-  </market_entry>
+<market_entry>
+  <id>BTable</id>
+  <type>Platform</type>
+  <img>http://www.biztech.it/btable/img/btable.png</img>
+  <small_img>http://www.biztech.it/btable/img/btable.png</small_img>
+  <name>BTable</name>
+  <category>	
+    <name>Dashboards</name>
+    <parent>
+      <name>Apps</name>
+    </parent>
+  </category>
+  <documentation_url>http://www.biztech.it/btable</documentation_url>
+  <description>BTable is a component for the Community Dashboard Designer (CDE) that extends the standard Table
+    Component with OLAP functionalities and provides a new drill experience... drill anywhere!
+  </description>
+  <author>Biz Tech</author>
+  <author_url>http://www.biztech.it</author_url>
+  <author_logo>http://www.biztech.it/btable/img/biztech.png</author_logo>
+  <dependencies>CDE, CDF, CDA</dependencies>
+  <license>MPL 2.0</license>
+  <installation_notes><![CDATA[This plugin requires CDA and CDE installed in the Pentaho BIServer and has been developed using Sparkl. <br /><br /> 
+Some <a href="http://bonomma.blogspot.it/2017/01/btable-pre-or-post-installation.html" target="_blank">pre-installation steps</a> are required in order to let all samples work perfectly]]>
+  </installation_notes>
+<versions>
+    <version>
+      <branch>STABLE</branch>
+      <version>3.6</version>
+      <name>Stable</name>
+      <package_url>https://heanet.dl.sourceforge.net/project/btable/Version3.0-3.6/BTable-pentaho7-3.6-STABLE.zip</package_url>
+      <samples_url>https://heanet.dl.sourceforge.net/project/btable/Version3.0-3.6/BTable-samples-pentaho7-3.6-STABLE.zip</samples_url>
+      <!--package_url>http://downloads.sourceforge.net/project/btable/Version2.1/BTable-pentaho5-STABLE-2.1.zip</package_url-->
+      <!--samples_url>http://downloads.sourceforge.net/project/btable/Version2.1/BTable-samples-pentaho5-STABLE-2.1.zip</samples_url-->
+      <description>Release 3.0</description>
+      <build_id>1</build_id>
+      <min_parent_version>7.0</min_parent_version>
+      <development_stage>
+        <lane>Community</lane>
+        <phase>2</phase>
+      </development_stage>
+    </version>
+    <version>
+      <branch>STABLE</branch>
+      <version>3.0</version>
+      <name>Stable</name>
+      <package_url>https://heanet.dl.sourceforge.net/project/btable/Version3.0-3.6/BTable-pentaho5-and-pentaho6-3.0-STABLE.zip</package_url>
+      <samples_url>https://heanet.dl.sourceforge.net/project/btable/Version3.0-3.6/BTable-samples-pentaho5-and-pentaho6-3.0-STABLE.zip</samples_url>
+      <description>Release 3.0</description>
+      <build_id>1</build_id>
+      <max_parent_version>6.9</max_parent_version>
+      <min_parent_version>5.0</min_parent_version>
+      <development_stage>
+        <lane>Community</lane>
+        <phase>2</phase>
+      </development_stage>
+    </version>
+    <version>
+      <branch>STABLE</branch>
+      <version>2.1</version>
+      <name>Stable</name>
+      <package_url>https://heanet.dl.sourceforge.net/project/btable/Version2.1/BTable-pentaho5-STABLE-2.1.zip</package_url>
+      <samples_url>https://heanet.dl.sourceforge.net/project/btable/Version2.1/BTable-samples-pentaho5-STABLE-2.1.zip</samples_url>
+      <description>Release 2.1</description>
+      <build_id>manual-20140610</build_id>
+      <max_parent_version>6.9</max_parent_version>
+      <min_parent_version>5.0</min_parent_version>
+      <development_stage>
+        <lane>Community</lane>
+        <phase>2</phase>
+      </development_stage>
+    </version>
+    <version>
+      <branch>STABLE</branch>
+      <version>2.1</version>
+      <name>Stable</name>
+      <package_url>https://heanet.dl.sourceforge.net/project/btable/Version2.1/BTable-pentaho4-STABLE-2.1.zip</package_url>
+      <samples_url>https://heanet.dl.sourceforge.net/project/btable/Version2.1/BTable-samples-pentaho4-STABLE-2.1.zip</samples_url>
+      <description>Release 2.1</description>
+      <build_id>manual-20140610</build_id>
+      <max_parent_version>4.9</max_parent_version>
+      <min_parent_version>1.0</min_parent_version>
+      <development_stage>
+        <lane>Community</lane>
+        <phase>2</phase>
+      </development_stage>
+    </version>
+  </versions>
+  <screenshots>
+    <screenshot>http://www.biztech.it/btable/img/BTable-Screenshot-01.png</screenshot>
+    <screenshot>http://www.biztech.it/btable/img/BTable-Screenshot-02.png</screenshot>
+    <screenshot>http://www.biztech.it/btable/img/BTable-Screenshot-03.png</screenshot>
+  </screenshots>
+</market_entry>
 
   <market_entry>
     <id>AAAR</id>


### PR DESCRIPTION
- Add installation instructions
- Add new 3.0 and 3.6 Versions
- Update download URLs from Sourceforge with direct mirrors 