### PR TITLE
Updated URLs

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -3117,7 +3117,7 @@ Some <a href="http://bonomma.blogspot.it/2017/01/btable-pre-or-post-installation
       <samples_url>https://heanet.dl.sourceforge.net/project/btable/Version3.0-3.6/BTable-samples-pentaho7-3.6-STABLE.zip</samples_url>
       <!--package_url>http://downloads.sourceforge.net/project/btable/Version2.1/BTable-pentaho5-STABLE-2.1.zip</package_url-->
       <!--samples_url>http://downloads.sourceforge.net/project/btable/Version2.1/BTable-samples-pentaho5-STABLE-2.1.zip</samples_url-->
-      <description>Release 3.0</description>
+      <description>Release 3.6</description>
       <build_id>1</build_id>
       <min_parent_version>7.0</min_parent_version>
       <development_stage>
@@ -3134,6 +3134,21 @@ Some <a href="http://bonomma.blogspot.it/2017/01/btable-pre-or-post-installation
       <description>Release 3.0</description>
       <build_id>1</build_id>
       <max_parent_version>6.9</max_parent_version>
+      <min_parent_version>6.0</min_parent_version>
+      <development_stage>
+        <lane>Community</lane>
+        <phase>2</phase>
+      </development_stage>
+    </version>
+    <version>
+      <branch>STABLE</branch>
+      <version>3.0</version>
+      <name>Stable</name>
+      <package_url>http://downloads.sourceforge.net/project/btable/Version3.0-3.6/BTable-pentaho5-and-pentaho6-3.0-STABLE.zip</package_url>
+      <samples_url>http://downloads.sourceforge.net/project/btable/Version3.0-3.6/BTable-samples-pentaho5-and-pentaho6-3.0-STABLE.zip</samples_url>
+      <description>Release 3.0</description>
+      <build_id>1</build_id>
+      <max_parent_version>5.9</max_parent_version>
       <min_parent_version>5.0</min_parent_version>
       <development_stage>
         <lane>Community</lane>
@@ -3149,6 +3164,21 @@ Some <a href="http://bonomma.blogspot.it/2017/01/btable-pre-or-post-installation
       <description>Release 2.1</description>
       <build_id>manual-20140610</build_id>
       <max_parent_version>6.9</max_parent_version>
+      <min_parent_version>6.0</min_parent_version>
+      <development_stage>
+        <lane>Community</lane>
+        <phase>2</phase>
+      </development_stage>
+    </version>
+    <version>
+      <branch>STABLE</branch>
+      <version>2.1</version>
+      <name>Stable</name>
+      <package_url>http://downloads.sourceforge.net/project/btable/Version2.1/BTable-pentaho5-STABLE-2.1.zip</package_url>
+      <samples_url>http://downloads.sourceforge.net/project/btable/Version2.1/BTable-samples-pentaho5-STABLE-2.1.zip</samples_url>
+      <description>Release 2.1</description>
+      <build_id>manual-20140610</build_id>
+      <max_parent_version>5.9</max_parent_version>
       <min_parent_version>5.0</min_parent_version>
       <development_stage>
         <lane>Community</lane>
@@ -3159,8 +3189,8 @@ Some <a href="http://bonomma.blogspot.it/2017/01/btable-pre-or-post-installation
       <branch>STABLE</branch>
       <version>2.1</version>
       <name>Stable</name>
-      <package_url>https://heanet.dl.sourceforge.net/project/btable/Version2.1/BTable-pentaho4-STABLE-2.1.zip</package_url>
-      <samples_url>https://heanet.dl.sourceforge.net/project/btable/Version2.1/BTable-samples-pentaho4-STABLE-2.1.zip</samples_url>
+      <package_url>http://downloads.sourceforge.net/project/btable/Version2.1/BTable-pentaho4-STABLE-2.1.zip</package_url>
+      <samples_url>http://downloads.sourceforge.net/project/btable/Version2.1/BTable-samples-pentaho4-STABLE-2.1.zip</samples_url>
       <description>Release 2.1</description>
       <build_id>manual-20140610</build_id>
       <max_parent_version>4.9</max_parent_version>


### PR DESCRIPTION
I just realized that Pentaho 5.x marketplace (probably is a Java7 problem) is not able to deal with  URLs starting with https for download. I'm actually using fixed links to Sourceforge mirror because it seems that HTTP Client PDI component used inside Pentaho Marketplace sometimes has problem with URL redirection. This is why I leaved direct mirror links starting with https for Pentaho version equals or greater than 6.0 while I used stardard http URLs for previous version (hoping they work fine in most cases). NOTE: I don't want to leave Sourceforge because I really love its analystics about downloads.   