### PR TITLE
d3ComponentLibrary - new plugin version for 7.x

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -2038,14 +2038,31 @@ A landing tab can optionally be presented, which can be used to any of the prede
     <versions>
       <version>
         <branch>RELEASE</branch>
+        <version>17.07.24</version>
+        <name>RELEASE</name>
+        <package_url>
+          http://ctools.pentaho.com/files/d3ComponentLibrary/17.07.24/d3ComponentLibrary-17.07.24.zip
+        </package_url>
+        <description>Latest Release</description>
+        <build_id/>
+        <max_parent_version>7.9</max_parent_version>
+        <min_parent_version>7.0</min_parent_version>
+        <development_stage>
+          <lane>Community</lane>
+          <phase>2</phase>
+        </development_stage>
+      </version>
+      <version>
+        <branch>RELEASE</branch>
         <version>14.06.18</version>
         <name>RELEASE</name>
         <package_url>
           http://ctools.pentaho.com/files/d3ComponentLibrary/14.06.18/d3ComponentLibrary-14.06.18.zip
         </package_url>
-        <description>Latest Release</description>
+        <description>For Pentaho versions prior to 7.0</description>
         <build_id/>
         <min_parent_version>5.0</min_parent_version>
+        <max_parent_version>5.9</max_parent_version>
         <development_stage>
           <lane>Community</lane>
           <phase>2</phase>

--- a/marketplace.xml
+++ b/marketplace.xml
@@ -2053,7 +2053,7 @@ A landing tab can optionally be presented, which can be used to any of the prede
         </development_stage>
       </version>
       <version>
-        <branch>RELEASE</branch>
+        <branch>PENTAHO5</branch>
         <version>14.06.18</version>
         <name>RELEASE</name>
         <package_url>


### PR DESCRIPTION
Updated d3ComponentLibrary Marketplace entry to make it available for Pentaho 7.x versions.