### PR TITLE
Update Pivot4J to build #439

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -3065,10 +3065,10 @@ Having trouble with this project? Feel free to report a issue on <a target='NO_B
       <version>
         <branch>Development</branch>
         <version>1.0-SNAPSHOT</version>
-        <build_id>425</build_id>
+        <build_id>439</build_id>
         <name>Latest snapshot</name>
         <package_url>
-          https://ci.greencatsoft.com/job/Pivot4J/425/artifact/pivot4j-pentaho/target/pivot4j-pentaho-1.0-SNAPSHOT-plugin.zip
+          https://ci.greencatsoft.com/job/Pivot4J/439/artifact/pivot4j-pentaho/target/pivot4j-pentaho-1.0-SNAPSHOT-plugin.zip
         </package_url>
         <description>The latest development snapshot build.</description>
         <min_parent_version>6.0</min_parent_version>


### PR DESCRIPTION
- Pentaho CDE widget - add parameters support - add iframe refresh.
- Added option to include 'All member' when place hierarchy.
- #170: Do not use cell ordinal as command parameter.
- #202: Fix error with drillthrough when changing the cube.
- Enabled export functionality in embedded report.
- Fixed issue #218 Correct support for non-numeric measure values.
- #216: Simplify embeded view by removing layouts.
- Fixed #220 Wrong table columns rendered with property column.
- #222 Optimze table rendering.
- Update Mondrian to 3.12.0.19-384.