### PR TITLE
FusionCharts-5 fix invalid certificate 

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -3557,8 +3557,8 @@ Some <a href="http://bonomma.blogspot.it/2017/01/btable-pre-or-post-installation
         <branch>Release</branch>
         <version>5.0.0</version>
         <name>Latest</name>
-        <package_url>https://www.xpand-it.com/wp-content/uploads/2017/11/fusion_plugin-5.0.0.zip</package_url>
-        <samples_url>https://www.xpand-it.com/wp-content/uploads/2017/11/fusion_samples-5.0.0.zip </samples_url>
+        <package_url>http://www.xpand-it.com/wp-content/uploads/2017/11/fusion_plugin-5.0.0.zip</package_url>
+        <samples_url>http://www.xpand-it.com/wp-content/uploads/2017/11/fusion_samples-5.0.0.zip </samples_url>
         <max_parent_version>7.9.99</max_parent_version>
         <min_parent_version>7.1.0</min_parent_version>
         <development_stage>


### PR DESCRIPTION
Java 8 does not provide the trusted certificate required. Switching to HTTP request.