### PR TITLE
1.4 release of CPython. Adds support for specifying the path to the p…

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -5895,8 +5895,8 @@ any translation issues or suggestions for improvement
     <versions>
       <version>
 	<branch>Trunk</branch>
-	<version>1.3</version>
-      <package_url>https://github.com/pentaho-labs/pentaho-cpython-plugin/releases/download/v1.3/pentaho-cpython-plugin-package-1.3-SNAPSHOT.zip</package_url>
+	<version>1.4</version>
+      <package_url>https://github.com/pentaho-labs/pentaho-cpython-plugin/releases/download/v1.4/pentaho-cpython-plugin-package-1.4.zip</package_url>
 
       <development_stage>
         <lane>Customer</lane>


### PR DESCRIPTION
…ython exe via a Kettle variable (pdi.cpython.command). Takes precedence over both the java property and environment variable for this). Also plumbed some logging through to PythonSession so that info (at debug level) is output on the path to the python exe and current state of the PATH variable. These changes are useful for getting the step debugged and working in visual MR.