### PR TITLE
Upgrade of AWS SQS Reader Plugin to version 0.9.1

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -12329,10 +12329,10 @@ Uses the MarkLogic Data Movement Java SDK. Works with MarkLogic 9.0 and above on
     <versions>
       <version>
         <branch>Stable</branch>
-        <version>0.9</version>
-        <package_url>https://github.com/FreddyFFM/PDIPlugin-AWS-SQS-Reader/releases/download/0.9/AWS-SQS-Reader-0.9.zip</package_url>
+        <version>0.9.1</version>
+        <package_url>https://github.com/FreddyFFM/PDIPlugin-AWS-SQS-Reader/releases/download/0.9.1/AWS-SQS-Reader-0.9.1.zip</package_url>
         <source_url>https://github.com/FreddyFFM/PDIPlugin-AWS-SQS-Reader</source_url>
-	<min_parent_version>6.1</min_parent_version>
+	<min_parent_version>7.1</min_parent_version>
         <development_stage>
           <lane>Community</lane>
           <phase>2</phase>


### PR DESCRIPTION
Hi,
I updated the AWS SQS plugin and released a new Version (0.9.1) - please update Pentaho Marketplace.

Michael