### PR TITLE
fix package_url typo

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -9446,13 +9446,13 @@ With this plugin you can:
            <parent>
             <name>PDI Plugins</name>
           </parent>
-    	</category>		
+    	</category>
 		<documentation_url>https://sourceforge.net/p/arsoutputplugin/wiki/Home/</documentation_url>
 		<description><![CDATA[This plugin is required for the "ARS Output (BMC Remedy)" step plugin.
-It's not working with other database based plugins. 
-		
-** THE AR SYSTEM API JARS ARE NOT INCLUDED, YOU NEED TO ** 
-** COPY THE JARS INTO THE DATA-INTEGRATION LIB DIRECTORY. **  
+It's not working with other database based plugins.
+
+** THE AR SYSTEM API JARS ARE NOT INCLUDED, YOU NEED TO **
+** COPY THE JARS INTO THE DATA-INTEGRATION LIB DIRECTORY. **
 If you use api < 7.5 or running the plugin against a remedy version < 7.5, you need to copy the native libs
 in addition and to adjust the PATH/LD_LIBRARY_PATH variables. See the installation notes.
 ( readme.txt within the plugin path or https://sourceforge.net/p/arsoutputplugin/wiki/Installation/)
@@ -9469,11 +9469,11 @@ in addition and to adjust the PATH/LD_LIBRARY_PATH variables. See the installati
 				<package_url>https://github.com/seschmid/PDIARSystemPlugins/releases/download/pdiplugins/arsdatabase-0.7.0-SNAPSHOT.zip</package_url>
 				<description>Trunk Snapshot. Install at your own risk...</description>
 			    <min_parent_version>5.0</min_parent_version>
-      			<max_parent_version>8.1</max_parent_version> 
+      			<max_parent_version>8.1</max_parent_version>
 			    <development_stage>
 			    	<lane>Community</lane>
         			<phase>3</phase>
-			    </development_stage> 
+			    </development_stage>
 			</version>
 			<version>
 				<branch>TRUNK</branch>
@@ -9484,7 +9484,7 @@ in addition and to adjust the PATH/LD_LIBRARY_PATH variables. See the installati
 			    <development_stage>
 			    	<lane>Community</lane>
         			<phase>3</phase>
-			    </development_stage> 
+			    </development_stage>
 			</version>
 		</versions>
 		<license_name>GPL 3.0</license_name>
@@ -9504,11 +9504,11 @@ in addition and to adjust the PATH/LD_LIBRARY_PATH variables. See the installati
           <parent>
             <name>PDI Plugins</name>
           </parent>
-        </category>		
+        </category>
 		<documentation_url>https://sourceforge.net/p/arsoutputplugin/wiki/Home/</documentation_url>
 		<description><![CDATA[This plugin allow to write to a BMC Remedy AR System server.
-		
-** THIS PLUGIN REQURIES THE AR-SYSTEM DATABASE PLUGIN "ARS Server (BMC Remedy)" ** 
+
+** THIS PLUGIN REQURIES THE AR-SYSTEM DATABASE PLUGIN "ARS Server (BMC Remedy)" **
 ( readme.txt within the plugin path or https://sourceforge.net/p/arsoutputplugin/wiki/Installation/)
 ]]></description>
 		<author>Sebastian Schmidt</author>
@@ -9526,12 +9526,12 @@ in addition and to adjust the PATH/LD_LIBRARY_PATH variables. See the installati
 			    <development_stage>
 			    	<lane>Community</lane>
         			<phase>3</phase>
-			    </development_stage> 
+			    </development_stage>
 			</version>
 		</versions>
 		<license_name>GPL 3.0</license_name>
 		<license_text>For more details see: http://www.gnu.org/licenses/gpl-3.0.txt</license_text>
-		<support_level>NOT_SUPPORTED</support_level> 
+		<support_level>NOT_SUPPORTED</support_level>
 	</market_entry>
 
 	<market_entry>
@@ -9546,11 +9546,11 @@ in addition and to adjust the PATH/LD_LIBRARY_PATH variables. See the installati
           <parent>
             <name>PDI Plugins</name>
           </parent>
-        </category>		
+        </category>
 		<documentation_url>https://sourceforge.net/p/arsoutputplugin/wiki/Home/</documentation_url>
 		<description><![CDATA[This plugin allow to read fromo a BMC Remedy AR System server.
-		
-** THIS PLUGIN REQURIES THE AR-SYSTEM DATABASE PLUGIN "ARS Server (BMC Remedy)" ** 
+
+** THIS PLUGIN REQURIES THE AR-SYSTEM DATABASE PLUGIN "ARS Server (BMC Remedy)" **
 ( readme.txt within the plugin path or https://sourceforge.net/p/arsoutputplugin/wiki/Installation/)
 ]]></description>
 		<author>Sebastian Schmidt</author>
@@ -9568,12 +9568,12 @@ in addition and to adjust the PATH/LD_LIBRARY_PATH variables. See the installati
 			    <development_stage>
 			    	<lane>Community</lane>
         			<phase>3</phase>
-			    </development_stage> 
+			    </development_stage>
 			</version>
 		</versions>
 		<license_name>GPL 3.0</license_name>
 		<license_text>For more details see: http://www.gnu.org/licenses/gpl-3.0.txt</license_text>
-		<support_level>NOT_SUPPORTED</support_level> 
+		<support_level>NOT_SUPPORTED</support_level>
 	</market_entry>
 
 
@@ -12542,7 +12542,7 @@ Uses the MarkLogic Data Movement Java SDK. Works with MarkLogic 9.0 and above on
       <version>
         <branch>Stable</branch>
         <version>1.3</version>
-        <package_url>https://github.com/socrata/socrata-kettle/releases/download/1.3/SocrataOutput.zip</package_url>
+        <package_url>https://github.com/socrata/socrata-kettle/releases/download/1.3/SocrataPlugin.zip</package_url>
         <source_url>https://github.com/socrata/socrata-kettle</source_url>
         <min_parent_version>6.1</min_parent_version>
         <development_stage>


### PR DESCRIPTION
package_url incorrectly pointed to SocrataOutput.zip and would error out when attempting to install, but should point to SocrataPlugin.zip. URL has been fixed.