### PR TITLE
Update marketplace.xml

### DIFF
--- a/marketplace.xml
+++ b/marketplace.xml
@@ -13271,12 +13271,12 @@ For more information <a target='NO_BLANK' href='https://www.datafor.com.cn/'>ple
     <versions>
 	<version>
 		<branch>STABLE</branch>
-		<version>4.01</version>
-		<name>Stable 4.01</name>
+		<version>4.02</version>
+		<name>Stable 4.02</name>
 		<package_url>
-			https://sourceforge.net/projects/datafor-visualizer/files/Modeler/Modeler-4.0.1.zip/download
+			https://sourceforge.net/projects/datafor-visualizer/files/Modeler/Modeler-4.0.2.zip/download
 		</package_url>
-		<description>Release 4.01</description>
+		<description>Release 4.02</description>
 		<min_parent_version>4.00</min_parent_version>
 		<development_stage>
 			<lane>Community</lane>


### PR DESCRIPTION
Version 4.0.2: Fixed the issue where topology diagram nodes in the model editor appeared blank in Safari.